### PR TITLE
Fixed #33 the __repr__ of Chunk

### DIFF
--- a/curtsies/formatstring.py
+++ b/curtsies/formatstring.py
@@ -15,6 +15,8 @@ on_blue(red('hello'))+' '+on_red(blue('there'))+green('!')
 '\x1b[31m\x1b[44mhello\x1b[49m\x1b[39m \x1b[34m\x1b[41mthere\x1b[49m\x1b[39m\x1b[32m!\x1b[39m'
 >>> fmtstr(', ').join(['a', fmtstr('b'), fmtstr('c', 'blue')])
 'a'+', '+'b'+', '+blue('c')
+>>> fmtstr('hello', 'red', bold=False)
+red('hello')
 """
 #TODO add a way to composite text without losing original formatting information
 

--- a/tests/test_fmtstr.py
+++ b/tests/test_fmtstr.py
@@ -193,6 +193,10 @@ class TestFmtStr(unittest.TestCase):
         a = blue(red('hello'))
         self.assertEqual(a, blue('hello'))
 
+    def test_repr(self):
+        self.assertEqual(fmtstr('hello', 'red', bold=False), red('hello'))
+        self.assertEqual(fmtstr('hello', 'red', bold=True), bold(red('hello')))
+
 class TestDoubleUnders(unittest.TestCase):
     def test_equality(self):
         x = fmtstr("adfs")


### PR DESCRIPTION
The `__repr__` method of `Chunk` was not checking the value of the attribute dictionary, so it was including "bold" when its value was `False`. 
