### PR TITLE
Fix the broken links to game examples.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -261,11 +261,11 @@ To set a timeout on the blocking get, treat it like a generator and call
 Examples
 --------
 
-* [Tic-Tac-Toe](tictactoeexample.py)
+* [Tic-Tac-Toe](/examples/tictactoeexample.py)
 
 ![screenshot](http://i.imgur.com/AucB55B.png)
 
-* [Avoid the X's game](gameexample.py)
+* [Avoid the X's game](/examples/gameexample.py)
 
 ![screenshot](http://i.imgur.com/nv1RQd3.png)
 


### PR DESCRIPTION
The tictactoe and the gameexample links were broken. This PR fixes the oversight in the link. 
