### PR TITLE
Add rxvt-style mappings for F1 to F4

### DIFF
--- a/curtsies/curtsieskeys.py
+++ b/curtsies/curtsieskeys.py
@@ -42,9 +42,13 @@ CURTSIES_NAMES = dict([
   (b'\x1b[1;10D', u'<Esc+Shift-LEFT>'),
 
   (b'\x1bOP',     u'<F1>'),
+  (b'\x1b[11~',   u'<F1>'),
   (b'\x1bOQ',     u'<F2>'),
+  (b'\x1b[12~',   u'<F2>'),
   (b'\x1bOR',     u'<F3>'),
+  (b'\x1b[13~',   u'<F3>'),
   (b'\x1bOS',     u'<F4>'),
+  (b'\x1b[14~',   u'<F4>'),
   (b'\x1b[15~',   u'<F5>'),
   (b'\x1b[17~',   u'<F6>'),
   (b'\x1b[18~',   u'<F7>'),


### PR DESCRIPTION
From `infocmp` (TERM=rxvt-unicode-256color):

```
… kf1=\E[11~,
kf10=\E[21~,_ kf11=\E[23~, kf12=\E[24~, kf13=\E[25~,
kf14=\E[26~, kf15=\E[28~, kf16=\E[29~, kf17=\E[31~,
kf18=\E[32~, kf19=\E[33~, kf2=\E[12~, kf20=\E[34~,
kf3=\E[13~, kf4=\E[14~, kf5=\E[15~, kf6=\E[17~, kf7=\E[18~,
kf8=\E[19~, kf9=\E[20
```

Are there plans to use the terminal's terminfo to setup the mappings?
