### PR TITLE
Fix install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(name='curtsies',
       install_requires = [
           'blessings>=1.5',
           'wcwidth>=0.1.4',
-          'typing',
+          'typing; python_version<"3.5"',
       ],
       tests_require = [
           'mock',


### PR DESCRIPTION
typing is only required for Python 3.4 or below.