### PR TITLE
Fix raising NotImplementedError

### DIFF
--- a/curtsies/window.py
+++ b/curtsies/window.py
@@ -62,7 +62,7 @@ class BaseWindow(object):
         self._last_rendered_height = height
 
     def render_to_terminal(self, array, cursor_pos=(0, 0)):
-        raise NotImplemented
+        raise NotImplementedError
 
     def get_term_hw(self):
         """Returns current terminal height and width"""


### PR DESCRIPTION
`NotImplemented` is a sentinel object, not an exception type.
It was mistakenly used instead of `NotImplementedError`.