### PR TITLE
Turns out cursor pos resp does get interrupted

### DIFF
--- a/curtsies/window.py
+++ b/curtsies/window.py
@@ -344,8 +344,11 @@ class CursorAwareWindow(BaseWindow):
                         )
                     return c
                 except IOError:
-                    raise ValueError("cursor get pos response read interrupted")
-                    # find out if this ever really happens - if so, continue
+                    # apparently sometimes this happens: the only documented
+                    # case is Terminal on a Ubuntu 17.10 VM on osx 10.13.
+                    # see issue #732
+                    logger.info("stdin.read(1) that should never error just errored.")
+                    continue
 
         resp = ""
         while True:


### PR DESCRIPTION
Turns out this race does happen! Fixes https://github.com/bpython/bpython/issues/732