### PR TITLE
README bug fix: example script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ This is what using (nearly every feature of) curtsies looks like:
 ```python
 from __future__ import unicode_literals  # convenient for Python 2
 import random
+import sys
 
 from curtsies import FullscreenWindow, Input, FSArray
 from curtsies.fmtfuncs import red, bold, green, on_blue, yellow
@@ -24,7 +25,10 @@ with FullscreenWindow() as window:
             elif c == '<SPACE>':
                 a = FSArray(window.height, window.width)
             else:
-                s = repr(c).decode()
+			    if sys.version_info[0] == 2:
+				    s = repr(c).decode()
+				else:
+				    s = repr(c)
                 row = random.choice(range(window.height))
                 column = random.choice(range(window.width-len(s)))
                 color = random.choice([red, green, on_blue, yellow])


### PR DESCRIPTION
* The example script did not work in Python 3.x due to the string
  literal being loaded through repr().  The code was clearly written
  for Py 2.x and not tested against 3.x (probably a while ago).
* Adding a simple check for the major release version in order to try
  to decode() the string (Py2) or not (Py3) should address this.
* Note that Py2 output is as unicode strings and thus will display as
  "u'x'" while Py3 will only display "'x'" (assuming "x" was pressed).
* Tested on CPython 2.7 and 3.7.

Tested-by: Ben McGinnes <ben@adversary.org>
Signed-off-by: Ben McGinnes <ben@adversary.org>