### PR TITLE
Test if Input has an orig_sigint_handler before attempting to use it

### DIFF
--- a/curtsies/input.py
+++ b/curtsies/input.py
@@ -115,7 +115,7 @@ class Input(object):
 
     def __exit__(self, type=None, value=None, traceback=None):
         # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]) -> None
-        if self.sigint_event and is_main_thread():
+        if self.sigint_event and is_main_thread() and self.orig_sigint_handler is not None:
             signal.signal(signal.SIGINT, self.orig_sigint_handler)
         termios.tcsetattr(self.in_stream, termios.TCSANOW, self.original_stty)
 


### PR DESCRIPTION
I don't know what's going on or why this is occuring, but I'm getting
a exception due to this being none while trying to embed bpython into
the lldb debugger. For whatever reason the sigint handler is None
during __enter__ and thus this throws.

Simply test if None before attempting to use.