### PR TITLE
Revert "Test if Input has an orig_sigint_handler before attempting to use it"

### DIFF
--- a/curtsies/input.py
+++ b/curtsies/input.py
@@ -115,7 +115,7 @@ class Input(object):
 
     def __exit__(self, type=None, value=None, traceback=None):
         # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]) -> None
-        if self.sigint_event and is_main_thread() and self.orig_sigint_handler is not None:
+        if self.sigint_event and is_main_thread():
             signal.signal(signal.SIGINT, self.orig_sigint_handler)
         termios.tcsetattr(self.in_stream, termios.TCSANOW, self.original_stty)
 


### PR DESCRIPTION
Reverts bpython/curtsies#125

Whoops, I can't look at this right now so reverting, here's the test that failed:

https://travis-ci.org/bpython/curtsies/jobs/654109965?utm_medium=notification&utm_source=github_status