### PR TITLE
Revert "Revert "Test if Input has an orig_sigint_handler before attempting to use it""

### DIFF
--- a/curtsies/input.py
+++ b/curtsies/input.py
@@ -115,7 +115,7 @@ class Input(object):
 
     def __exit__(self, type=None, value=None, traceback=None):
         # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]) -> None
-        if self.sigint_event and is_main_thread():
+        if self.sigint_event and is_main_thread() and self.orig_sigint_handler is not None:
             signal.signal(signal.SIGINT, self.orig_sigint_handler)
         termios.tcsetattr(self.in_stream, termios.TCSANOW, self.original_stty)
 


### PR DESCRIPTION
Reverts bpython/curtsies#126

Turns out this was not the problem, we have something else wrong with tests. Sorry about that @lanza, and thanks for https://github.com/bpython/curtsies/pull/125