### PR TITLE
Revert Fixed escape sequence issue

### DIFF
--- a/curtsies/window.py
+++ b/curtsies/window.py
@@ -353,7 +353,7 @@ class CursorAwareWindow(BaseWindow):
             resp += c
             m = re.search(
                 "(?P<extra>.*)"
-                "(?P<CSI>\x1b[|\x9b)"
+                "(?P<CSI>\x1b\[|\x9b)"
                 "(?P<row>\\d+);(?P<column>\\d+)R",
                 resp,
                 re.DOTALL,


### PR DESCRIPTION
When using bpython with curtsies version 0.3.2, we get 

`"unterminated character set",
re.error: unterminated character set at position 22`

which points to a recent change made in window.py where we deleted an escape backslash character to fix #128.

This reverts PR #141 and therefore reopens issue #128.