### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 arch:
    - amd64
    - ppc64le
+
 notifications:
     webhooks:
         - secure: "SWXDWxa1mNV6Wr6fPP8MxYO69rOiMMilp475Z9a3V9B3S/xds+d0ye8msUD+D1W9lzhwrw9NSMUjuBrm0llAvBV2MVCjYeuZ4ACLuK7fqhh4+2V9OrhYCKQrjNmEicmqwe1H5Z09JGKnMEJGUxrqApkCucoY8xOJu1/jfS7R63I="
@@ -14,6 +15,7 @@ python:
     - "3.6"
     - "pypy"
     - "pypy3"
+ 
  jobs:
   exclude:
    - arch: ppc64le

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,13 @@ python:
     - "3.6"
     - "pypy"
     - "pypy3"
+ jobs:
+  exclude:
+   - arch: ppc64le
+     python: "pypy"
+   - arch: ppc64le
+     python: "pypy3"
+       
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+   - amd64
+   - ppc64le
 notifications:
     webhooks:
         - secure: "SWXDWxa1mNV6Wr6fPP8MxYO69rOiMMilp475Z9a3V9B3S/xds+d0ye8msUD+D1W9lzhwrw9NSMUjuBrm0llAvBV2MVCjYeuZ4ACLuK7fqhh4+2V9OrhYCKQrjNmEicmqwe1H5Z09JGKnMEJGUxrqApkCucoY8xOJu1/jfS7R63I="


### PR DESCRIPTION
Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.

The build is successful on both arch: amd64/ppc64le.


Please let me know if you need any further details.

Thank You !!