### PR TITLE
Adding Power support(ppc64le) with ci and testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ notifications:
         - secure: "SWXDWxa1mNV6Wr6fPP8MxYO69rOiMMilp475Z9a3V9B3S/xds+d0ye8msUD+D1W9lzhwrw9NSMUjuBrm0llAvBV2MVCjYeuZ4ACLuK7fqhh4+2V9OrhYCKQrjNmEicmqwe1H5Z09JGKnMEJGUxrqApkCucoY8xOJu1/jfS7R63I="
 
 language: python
-
+arch:
+    - amd64
+    - ppc64le
 python:
     - "2.7"
     - "3.4"
@@ -17,6 +19,15 @@ matrix:
         - python: 3.7
           dist: xenial
           sudo: true
+        - python: 3.7
+          arch: ppc64le
+          dist: xenial
+          sudo: true
+    exclude:
+        - arch : ppc64le
+          python : pypy
+        - arch : ppc64le
+          python : pypy3
 
 install:
     - "python setup.py install"


### PR DESCRIPTION
I am working for IBM to port cpu arch ppc64le for open sources.

This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro
on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.

This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model.

Please help to verify and merge.