### PR TITLE
Clean up both wakeup_fds

### DIFF
--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -141,3 +141,9 @@ class TestInput(unittest.TestCase):
         t = threading.Thread(target=use)
         t.start()
         t.join()
+
+    def test_cleanup(self):
+        input_generator = Input()
+        for i in range(1000):
+            with input_generator:
+                pass


### PR DESCRIPTION
I'm not sure this is covering everything yet, but it fixes the cleanup problem.

Careful, this test doesn't run in CI right now, use `pytest -s --doctest-modules ./curtsies ./tests` to run all tests locally.

Fixes #170