### PR TITLE
Fix linting and type annotation errors

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black codespell
+        pip install black
     - name: Check with black
       run: black --check .
 

--- a/curtsies/__init__.py
+++ b/curtsies/__init__.py
@@ -1,4 +1,5 @@
 """Terminal-formatted strings"""
+
 __version__ = "0.4.2"
 
 from .window import FullscreenWindow, CursorAwareWindow

--- a/curtsies/curtsieskeys.py
+++ b/curtsies/curtsieskeys.py
@@ -1,4 +1,5 @@
 """All the key sequences"""
+
 # If you add a binding, add something about your setup
 # if you can figure out why it's different
 

--- a/curtsies/events.py
+++ b/curtsies/events.py
@@ -1,4 +1,5 @@
 """Events for keystrokes and other input events"""
+
 import codecs
 import itertools
 import sys

--- a/curtsies/formatstring.py
+++ b/curtsies/formatstring.py
@@ -93,9 +93,11 @@ def stable_format_dict(d: Mapping) -> str:
     Does not work for dicts with unicode strings as values."""
     inner = ", ".join(
         "{}: {}".format(
-            repr(k)[1:]
-            if repr(k).startswith("u'") or repr(k).startswith('u"')
-            else repr(k),
+            (
+                repr(k)[1:]
+                if repr(k).startswith("u'") or repr(k).startswith('u"')
+                else repr(k)
+            ),
             v,
         )
         for k, v in sorted(d.items())

--- a/curtsies/input.py
+++ b/curtsies/input.py
@@ -57,6 +57,8 @@ class ReplacedSigIntHandler(ContextManager):
 class Input(ContextManager["Input"]):
     """Keypress and control event generator"""
 
+    in_stream: TextIO
+
     def __init__(
         self,
         in_stream: Optional[TextIO] = None,
@@ -82,6 +84,7 @@ class Input(ContextManager["Input"]):
         """
         if in_stream is None:
             in_stream = sys.__stdin__
+            assert in_stream is not None
         self.in_stream = in_stream
         self.unprocessed_bytes: List[bytes] = []  # leftover from stdin, unprocessed yet
         if isinstance(keynames, str):

--- a/curtsies/window.py
+++ b/curtsies/window.py
@@ -42,6 +42,7 @@ class BaseWindow(ContextManager):
         logger.debug("-------initializing Window object %r------" % self)
         if out_stream is None:
             out_stream = sys.__stdout__
+            assert out_stream is not None
         self.t = blessed.Terminal(stream=out_stream, force_styling=True)
         self.out_stream = out_stream
         self.hide_cursor = hide_cursor
@@ -241,10 +242,12 @@ class CursorAwareWindow(BaseWindow, ContextManager["CursorAwareWindow"]):
         Only use the render_to_terminal interface for moving the cursor.
     """
 
+    in_stream: TextIO
+
     def __init__(
         self,
-        out_stream: Optional[IO] = None,
-        in_stream: Optional[IO] = None,
+        out_stream: Optional[TextIO] = None,
+        in_stream: Optional[TextIO] = None,
         keep_last_line: bool = False,
         hide_cursor: bool = True,
         extra_bytes_callback: Optional[Callable[[bytes], None]] = None,
@@ -264,6 +267,7 @@ class CursorAwareWindow(BaseWindow, ContextManager["CursorAwareWindow"]):
         super().__init__(out_stream=out_stream, hide_cursor=hide_cursor)
         if in_stream is None:
             in_stream = sys.__stdin__
+            assert in_stream is not None
         self.in_stream = in_stream
         # whether we can use blessed to handle some operations
         self._use_blessed = (


### PR DESCRIPTION
The documentation fixes made in #184 highlighted the latest merged commit in the repository doesn't pass the Black formatting checks and mypy type annotation checks.

This fixes those.