### PR TITLE
Fix Shift+Arrow key mappings

### DIFF
--- a/curtsies/curtsieskeys.py
+++ b/curtsies/curtsieskeys.py
@@ -129,9 +129,9 @@ CURTSIES_NAMES = {
     b"\x1b[1;3H": '<Meta-HOME>',       # alt-home
     b"\x1b[1;3F": '<Meta-END>',        # alt-end
     b"\x1b[1;2C": '<Shift-RIGHT>',
-    b"\x1b[1;2B": '<Shift-RIGHT>',
-    b"\x1b[1;2D": '<Shift-RIGHT>',
-    b"\x1b[1;2A": '<Shift-RIGHT>',
+    b"\x1b[1;2B": '<Shift-DOWN>',
+    b"\x1b[1;2D": '<Shift-LEFT>',
+    b"\x1b[1;2A": '<Shift-UP>',
     b"\x1b[3;2~": '<Shift-DELETE>',
     b"\x1b[5;2~": '<Shift-PAGEUP>',
     b"\x1b[6;2~": '<Shift-PAGEDOWN>',

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -145,3 +145,35 @@ class TestSpecialKeys(unittest.TestCase):
 class TestPPEvent(unittest.TestCase):
     def test(self):
         self.assertEqual(events.pp_event("a"), "a")
+
+
+class TestShiftArrowMappings(unittest.TestCase):
+    def test_curtsies_names(self):
+        self.assertEqual(events.CURTSIES_NAMES[b"\x1b[1;2A"], "<Shift-UP>")
+        self.assertEqual(events.CURTSIES_NAMES[b"\x1b[1;2B"], "<Shift-DOWN>")
+        self.assertEqual(events.CURTSIES_NAMES[b"\x1b[1;2C"], "<Shift-RIGHT>")
+        self.assertEqual(events.CURTSIES_NAMES[b"\x1b[1;2D"], "<Shift-LEFT>")
+
+    def test_get_key_sequences(self):
+        # Ensure get_key resolves complete Shift+Arrow sequences
+        seq_up = [b"\x1b", b"[", b"1", b";", b"2", b"A"]
+        seq_down = [b"\x1b", b"[", b"1", b";", b"2", b"B"]
+        seq_right = [b"\x1b", b"[", b"1", b";", b"2", b"C"]
+        seq_left = [b"\x1b", b"[", b"1", b";", b"2", b"D"]
+
+        self.assertEqual(
+            [events.get_key(seq_up[:i], encoding="utf8") for i in range(1, len(seq_up) + 1)],
+            [None, None, None, None, None, "<Shift-UP>"]
+        )
+        self.assertEqual(
+            [events.get_key(seq_down[:i], encoding="utf8") for i in range(1, len(seq_down) + 1)],
+            [None, None, None, None, None, "<Shift-DOWN>"]
+        )
+        self.assertEqual(
+            [events.get_key(seq_right[:i], encoding="utf8") for i in range(1, len(seq_right) + 1)],
+            [None, None, None, None, None, "<Shift-RIGHT>"]
+        )
+        self.assertEqual(
+            [events.get_key(seq_left[:i], encoding="utf8") for i in range(1, len(seq_left) + 1)],
+            [None, None, None, None, None, "<Shift-LEFT>"]
+        )


### PR DESCRIPTION
Map ESC [ 1 ; 2 A/B/C/D to <Shift-UP/DOWN/RIGHT/LEFT> instead of all mapping to <Shift-RIGHT>.

Add unit tests for direct CURTSIES_NAMES entries and get_key sequence resolution.